### PR TITLE
Changes developers style to use flexbox.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,8 @@
 .developers{
-  margin: 0 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .developer{


### PR DESCRIPTION
Uses flexbox to center align developers

<img width="491" alt="screen shot 2015-09-07 at 10 57 32 am" src="https://cloud.githubusercontent.com/assets/691365/9719086/5b46aba4-554f-11e5-9ed6-46bf12eade58.png">

this seems to work better than `margin: 0 50%` because it accounts for the size of the developer boxes.
